### PR TITLE
Set Kotlin module name to fix library conflict

### DIFF
--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -22,6 +22,11 @@ val prettyLibraryName = "ModernAndroidPreferences"
 
 android {
     compileSdkVersion(30)
+    compileOptions {
+        kotlinOptions {
+            freeCompilerArgs += listOf("-module-name", libraryName)
+        }
+    }
     defaultConfig {
         minSdkVersion(21)
         targetSdkVersion(30)

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -22,11 +22,6 @@ val prettyLibraryName = "ModernAndroidPreferences"
 
 android {
     compileSdkVersion(30)
-    compileOptions {
-        kotlinOptions {
-            freeCompilerArgs += listOf("-module-name", libraryName)
-        }
-    }
     defaultConfig {
         minSdkVersion(21)
         targetSdkVersion(30)
@@ -45,6 +40,8 @@ android {
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
+        @Suppress("SuspiciousCollectionReassignment")
+        freeCompilerArgs += listOf("-module-name", libraryName)
     }
     lintOptions {
         isAbortOnError = false


### PR DESCRIPTION
By default, the Kotlin compiler creates a kotlin_module file with the name of the Gradle module. The resulting name is "library_release.kotlin_module" for this library, which conflicts with other libraries that also use the default generic "library" name. This causes builds to fail when multiple such libraries are used in the same project:

```
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > More than one file was found with OS independent path 'META-INF/library_release.kotlin_module'.
```

Set a unique Kotlin module name to fix the issue.